### PR TITLE
Feature/caffeine book detail logic g

### DIFF
--- a/Techome/Techome.xcodeproj/project.pbxproj
+++ b/Techome/Techome.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		2ABF49482856DCAD000E3387 /* BarChart in Frameworks */ = {isa = PBXBuildFile; productRef = 2ABF49472856DCAD000E3387 /* BarChart */; };
+		5220177F2859B6AD005A5BEC /* CaffeineBookDetailStateHolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5220177E2859B6AD005A5BEC /* CaffeineBookDetailStateHolder.swift */; };
 		52AFC473285704AB000199DF /* AddSideEffectStateHolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52AFC472285704AB000199DF /* AddSideEffectStateHolder.swift */; };
 		52AFC475285826B6000199DF /* Test_G.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52AFC474285826B6000199DF /* Test_G.swift */; };
 		52AFC4782858614E000199DF /* CaffeineBookDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52AFC4772858614E000199DF /* CaffeineBookDetailView.swift */; };
@@ -47,6 +48,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		5220177E2859B6AD005A5BEC /* CaffeineBookDetailStateHolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaffeineBookDetailStateHolder.swift; sourceTree = "<group>"; };
 		52AFC472285704AB000199DF /* AddSideEffectStateHolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddSideEffectStateHolder.swift; sourceTree = "<group>"; };
 		52AFC474285826B6000199DF /* Test_G.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_G.swift; sourceTree = "<group>"; };
 		52AFC4772858614E000199DF /* CaffeineBookDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaffeineBookDetailView.swift; sourceTree = "<group>"; };
@@ -234,6 +236,7 @@
 			children = (
 				AB18CCEA2856D8B300DD1C5A /* tempViewModel.swift */,
 				52AFC472285704AB000199DF /* AddSideEffectStateHolder.swift */,
+				5220177E2859B6AD005A5BEC /* CaffeineBookDetailStateHolder.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -378,6 +381,7 @@
 				DA11291228570F4C0065BD33 /* TestView_P.swift in Sources */,
 				AB18CD002856D8B300DD1C5A /* AddSideEffectView.swift in Sources */,
 				AB18CCF92856D8B300DD1C5A /* tempModel.swift in Sources */,
+				5220177F2859B6AD005A5BEC /* CaffeineBookDetailStateHolder.swift in Sources */,
 				AB18CCEF2856D8B300DD1C5A /* IntakeRepository.swift in Sources */,
 				AB18CCF02856D8B300DD1C5A /* tempExtension.swift in Sources */,
 				52AFC4782858614E000199DF /* CaffeineBookDetailView.swift in Sources */,

--- a/Techome/Techome.xcodeproj/project.pbxproj
+++ b/Techome/Techome.xcodeproj/project.pbxproj
@@ -172,9 +172,9 @@
 		AB18CCD72856D8B300DD1C5A /* Intake */ = {
 			isa = PBXGroup;
 			children = (
+				AB18CCDA2856D8B300DD1C5A /* Franchise.swift */,
 				AB18CCD82856D8B300DD1C5A /* Beverage.swift */,
 				AB18CCD92856D8B300DD1C5A /* IntakeRecord.swift */,
-				AB18CCDA2856D8B300DD1C5A /* Franchise.swift */,
 			);
 			path = Intake;
 			sourceTree = "<group>";

--- a/Techome/Techome/Global/Manager/JSONManager.swift
+++ b/Techome/Techome/Global/Manager/JSONManager.swift
@@ -20,7 +20,6 @@ final class JSONManager {
             fatalError("Invalid URL")
         }
         
-        print(url)
         let fileURL = url.appendingPathComponent(filename)
         
         var data = Data()

--- a/Techome/Techome/TechomeApp.swift
+++ b/Techome/Techome/TechomeApp.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct TechomeApp: App {
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            CaffeineBookDetailView()
         }
     }
 }

--- a/Techome/Techome/TechomeApp.swift
+++ b/Techome/Techome/TechomeApp.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct TechomeApp: App {
     var body: some Scene {
         WindowGroup {
-            CaffeineBookDetailView()
+            ContentView()
         }
     }
 }

--- a/Techome/Techome/ViewModel/CaffeineBookDetailStateHolder.swift
+++ b/Techome/Techome/ViewModel/CaffeineBookDetailStateHolder.swift
@@ -1,0 +1,15 @@
+//
+//  CaffeineBookDetailStateHolder.swift
+//  Techome
+//
+//  Created by 김유나 on 2022/06/15.
+//
+
+import Foundation
+
+class CaffeineBookDetailStateHolder: ObservableObject {
+    
+    @Published var Beverage: Beverage = dummyBeverages[0]
+    @Published var isSelected: Int = 0
+
+}

--- a/Techome/Techome/ViewModel/CaffeineBookDetailStateHolder.swift
+++ b/Techome/Techome/ViewModel/CaffeineBookDetailStateHolder.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class CaffeineBookDetailStateHolder: ObservableObject {
+final class CaffeineBookDetailStateHolder: ObservableObject {
     
     @Published var Beverage: Beverage = dummyBeverages[0]
     @Published var isSelected: Int = 0

--- a/Techome/Techome/Views/CaffeineBookDetail/CaffeineBookDetailView.swift
+++ b/Techome/Techome/Views/CaffeineBookDetail/CaffeineBookDetailView.swift
@@ -41,7 +41,7 @@ struct CaffeineBookDetailLayoutValue {
 
 struct CaffeineBookDetailView: View {
     
-    var caffeineBookDetailStates = CaffeineBookDetailStateHolder()
+    let caffeineBookDetailStates = CaffeineBookDetailStateHolder()
         
     var body: some View {
         NavigationView {
@@ -51,7 +51,7 @@ struct CaffeineBookDetailView: View {
                 VStack(spacing: .zero) {
                     VStack(alignment: .center, spacing: .zero) {
                         CaffeineBeverage()
-                        CaffeineSizeButtonGroup()
+                        BeverageSizeButtonGroup()
                         CaffeineInfoGroup()
                     }
                     .environmentObject(caffeineBookDetailStates)
@@ -97,14 +97,14 @@ struct CaffeineBeverage: View {
     }
 }
 
-struct CaffeineSizeButtonGroup: View {
+struct BeverageSizeButtonGroup: View {
 
     @EnvironmentObject var caffeineBookDetailStates: CaffeineBookDetailStateHolder
 
     var body: some View {
         HStack(spacing: CaffeineBookDetailLayoutValue.Padding.buttonBetweenSpace) {
             ForEach(0 ..< caffeineBookDetailStates.Beverage.sizeInfo.count, id: \.self) { buttonIndex in
-                CaffeineSizeButton(size: caffeineBookDetailStates.Beverage.sizeInfo[buttonIndex].name, volume: caffeineBookDetailStates.Beverage.franchise.getSizeAmount(size: caffeineBookDetailStates.Beverage.sizeInfo[buttonIndex].name), buttonIndex: buttonIndex)
+                BeverageSizeButton(size: caffeineBookDetailStates.Beverage.sizeInfo[buttonIndex].name, volume: caffeineBookDetailStates.Beverage.franchise.getSizeAmount(size: caffeineBookDetailStates.Beverage.sizeInfo[buttonIndex].name), buttonIndex: buttonIndex)
             }
         }
         .padding(.top, CaffeineBookDetailLayoutValue.Padding.buttonGroupTop)
@@ -112,7 +112,7 @@ struct CaffeineSizeButtonGroup: View {
     }
 }
 
-struct CaffeineSizeButton: View {
+struct BeverageSizeButton: View {
     
     @EnvironmentObject var caffeineBookDetailStates: CaffeineBookDetailStateHolder
     
@@ -130,7 +130,7 @@ struct CaffeineSizeButton: View {
                     Text(size)
                         .font(.title2)
                         .foregroundColor(caffeineBookDetailStates.isSelected == buttonIndex ? .white : .customBlack)
-                    Text("\(String(volume))ml")
+                    Text("\(volume)ml")
                         .padding(.top, CaffeineBookDetailLayoutValue.Padding.buttonTextSpace)
                         .font(.caption)
                         .foregroundColor(caffeineBookDetailStates.isSelected == buttonIndex ? .white : .secondaryTextGray)

--- a/Techome/Techome/Views/CaffeineBookDetail/CaffeineBookDetailView.swift
+++ b/Techome/Techome/Views/CaffeineBookDetail/CaffeineBookDetailView.swift
@@ -41,7 +41,9 @@ struct CaffeineBookDetailLayoutValue {
 
 struct CaffeineBookDetailView: View {
     
-    @State var Test : Beverage = Beverage(name: "카페 아메리카노", franchise: .starbucks, sizeInfo: [SizeInfo(name: "Tall", caffeineAmount: 150, defaultShotCount: 2), SizeInfo(name: "Grande", caffeineAmount: 225, defaultShotCount: 3), SizeInfo(name: "Venti", caffeineAmount: 300, defaultShotCount: 4)])
+    @State var Test : Beverage = dummyBeverages[0]
+    
+    @State var isSelected: Int = 0
     
     var body: some View {
         NavigationView {
@@ -51,8 +53,8 @@ struct CaffeineBookDetailView: View {
                 VStack {
                     VStack(alignment: .center, spacing: .zero) {
                         CaffeineBeverage(test: Test)
-                        CaffeineSizeButtonGroup(test: Test)
-                        CaffeineInfoGroup(test: Test)
+                        CaffeineSizeButtonGroup(test: Test, isSelected: $isSelected)
+                        CaffeineInfoGroup(test: Test, isSelected: $isSelected)
                     }
                     .background(.white)
                     .clipShape(RoundedRectangle(cornerRadius: CaffeineBookDetailLayoutValue.Radius.backgroundCard))
@@ -97,10 +99,8 @@ struct CaffeineBeverage: View {
 }
 
 struct CaffeineSizeButtonGroup: View {
-    
-    @State var isSelected: Int = 0
-    
     var test: Beverage
+    @Binding var isSelected: Int
 
     var body: some View {
         HStack(spacing: CaffeineBookDetailLayoutValue.Padding.buttonBetweenSpace) {
@@ -147,11 +147,13 @@ struct CaffeineInfoGroup: View {
     
     var test: Beverage
     
+    @Binding var isSelected: Int
+    
     var body: some View {
         Group {
-            CaffeineInfoRow(label: "샷 수", info: String(test.sizeInfo[0].defaultShotCount)+"샷")
+            CaffeineInfoRow(label: "샷 수", info: String(test.sizeInfo[isSelected].defaultShotCount)+"샷")
                 .padding(.top, CaffeineBookDetailLayoutValue.Padding.infoRowBetweenSpaceExceptCaption)
-            CaffeineInfoRow(label: "카페인", info: String(test.sizeInfo[0].caffeineAmount) + "mg")
+            CaffeineInfoRow(label: "카페인", info: String(test.sizeInfo[isSelected].caffeineAmount) + "mg")
                 .padding(.top, CaffeineBookDetailLayoutValue.Padding.infoRowBetweenSpaceExceptCaption)
             HStack {
                 Spacer()

--- a/Techome/Techome/Views/CaffeineBookDetail/CaffeineBookDetailView.swift
+++ b/Techome/Techome/Views/CaffeineBookDetail/CaffeineBookDetailView.swift
@@ -48,7 +48,7 @@ struct CaffeineBookDetailView: View {
             ZStack {
                 Color.backgroundCream.edgesIgnoringSafeArea(.all)
                 
-                VStack {
+                VStack(spacing: .zero) {
                     VStack(alignment: .center, spacing: .zero) {
                         CaffeineBeverage()
                         CaffeineSizeButtonGroup()

--- a/Techome/Techome/Views/CaffeineBookDetail/CaffeineBookDetailView.swift
+++ b/Techome/Techome/Views/CaffeineBookDetail/CaffeineBookDetailView.swift
@@ -40,6 +40,9 @@ struct CaffeineBookDetailLayoutValue {
 }
 
 struct CaffeineBookDetailView: View {
+    
+    @State var Test : Beverage = Beverage(name: "카페 아메리카노", franchise: .starbucks, sizeInfo: [SizeInfo(name: "Tall", caffeineAmount: 150, defaultShotCount: 2), SizeInfo(name: "Grande", caffeineAmount: 225, defaultShotCount: 3), SizeInfo(name: "Venti", caffeineAmount: 300, defaultShotCount: 4)])
+    
     var body: some View {
         NavigationView {
             ZStack {
@@ -47,9 +50,9 @@ struct CaffeineBookDetailView: View {
                 
                 VStack {
                     VStack(alignment: .center, spacing: .zero) {
-                        CaffeineBeverage()
-                        CaffeineSizeButtonGroup()
-                        CaffeineInfoGroup()
+                        CaffeineBeverage(test: Test)
+                        CaffeineSizeButtonGroup(test: Test)
+                        CaffeineInfoGroup(test: Test)
                     }
                     .background(.white)
                     .clipShape(RoundedRectangle(cornerRadius: CaffeineBookDetailLayoutValue.Radius.backgroundCard))
@@ -76,14 +79,17 @@ struct CaffeineBookDetailView: View {
 }
 
 struct CaffeineBeverage: View {
+    
+    var test: Beverage
+    
     var body: some View {
-        Text("아메리카노")
+        Text(test.name)
             .font(.title)
             .fontWeight(.bold)
             .foregroundColor(.customBlack)
             .padding(.top, CaffeineBookDetailLayoutValue.Padding.titleTop)
         
-        Text("스타벅스")
+        Text(test.franchise.getFranchiseName())
             .font(.caption)
             .foregroundColor(.secondaryTextGray)
             .padding(.top, CaffeineBookDetailLayoutValue.Padding.franchiseTop)
@@ -93,15 +99,14 @@ struct CaffeineBeverage: View {
 struct CaffeineSizeButtonGroup: View {
     
     @State var isSelected: Int = 0
+    
+    var test: Beverage
 
     var body: some View {
         HStack(spacing: CaffeineBookDetailLayoutValue.Padding.buttonBetweenSpace) {
-            ForEach(0 ..< 3, id: \.self) { buttonIndex in
-                CaffeineSizeButton(size: "Tall", volume: "355ml", buttonIndex: buttonIndex, isSelected: $isSelected)
+            ForEach(0 ..< test.sizeInfo.count, id: \.self) { buttonIndex in
+                CaffeineSizeButton(size: test.sizeInfo[buttonIndex].name, volume: test.franchise.getSizeAmount(size: test.sizeInfo[buttonIndex].name), buttonIndex: buttonIndex, isSelected: $isSelected)
             }
-//            CaffeineSizeButton(size: "Tall", volume: "355ml")
-//            CaffeineSizeButton(size: "Grande", volume: "450ml")
-//            CaffeineSizeButton(size: "Venti", volume: "530ml")
         }
         .padding(.top, CaffeineBookDetailLayoutValue.Padding.buttonGroupTop)
         .padding(.bottom, CaffeineBookDetailLayoutValue.Padding.buttonGroupBottom)
@@ -111,7 +116,7 @@ struct CaffeineSizeButtonGroup: View {
 struct CaffeineSizeButton: View {
     
     var size: String
-    var volume: String
+    var volume: Int
     var buttonIndex: Int
     
     @Binding var isSelected: Int
@@ -126,7 +131,7 @@ struct CaffeineSizeButton: View {
                     Text(size)
                         .font(.title2)
                         .foregroundColor(isSelected == buttonIndex ? .white : .customBlack)
-                    Text(volume)
+                    Text("\(String(volume))ml")
                         .padding(.top, CaffeineBookDetailLayoutValue.Padding.buttonTextSpace)
                         .font(.caption)
                         .foregroundColor(isSelected == buttonIndex ? .white : .secondaryTextGray)
@@ -140,11 +145,13 @@ struct CaffeineSizeButton: View {
 
 struct CaffeineInfoGroup: View {
     
+    var test: Beverage
+    
     var body: some View {
         Group {
-            CaffeineInfoRow(label: "샷 수", info: "2샷")
+            CaffeineInfoRow(label: "샷 수", info: String(test.sizeInfo[0].defaultShotCount)+"샷")
                 .padding(.top, CaffeineBookDetailLayoutValue.Padding.infoRowBetweenSpaceExceptCaption)
-            CaffeineInfoRow(label: "카페인", info: "175mg")
+            CaffeineInfoRow(label: "카페인", info: String(test.sizeInfo[0].caffeineAmount) + "mg")
                 .padding(.top, CaffeineBookDetailLayoutValue.Padding.infoRowBetweenSpaceExceptCaption)
             HStack {
                 Spacer()

--- a/Techome/Techome/Views/CaffeineBookDetail/CaffeineBookDetailView.swift
+++ b/Techome/Techome/Views/CaffeineBookDetail/CaffeineBookDetailView.swift
@@ -91,11 +91,17 @@ struct CaffeineBeverage: View {
 }
 
 struct CaffeineSizeButtonGroup: View {
+    
+    @State var isSelected: Int = 0
+
     var body: some View {
         HStack(spacing: CaffeineBookDetailLayoutValue.Padding.buttonBetweenSpace) {
-            CaffeineSizeButton(size: "Tall", volume: "355ml")
-            CaffeineSizeButton(size: "Grande", volume: "450ml")
-            CaffeineSizeButton(size: "Venti", volume: "530ml")
+            ForEach(0 ..< 3, id: \.self) { buttonIndex in
+                CaffeineSizeButton(size: "Tall", volume: "355ml", buttonIndex: buttonIndex, isSelected: $isSelected)
+            }
+//            CaffeineSizeButton(size: "Tall", volume: "355ml")
+//            CaffeineSizeButton(size: "Grande", volume: "450ml")
+//            CaffeineSizeButton(size: "Venti", volume: "530ml")
         }
         .padding(.top, CaffeineBookDetailLayoutValue.Padding.buttonGroupTop)
         .padding(.bottom, CaffeineBookDetailLayoutValue.Padding.buttonGroupBottom)
@@ -106,25 +112,28 @@ struct CaffeineSizeButton: View {
     
     var size: String
     var volume: String
+    var buttonIndex: Int
+    
+    @Binding var isSelected: Int
     
     var body: some View {
         RoundedRectangle(cornerRadius: CaffeineBookDetailLayoutValue.Radius.sizeButton)
             .frame(width: CaffeineBookDetailLayoutValue.Size.sizeButtonWidth, height: CaffeineBookDetailLayoutValue.Size.sizeButtonHeight)
-            .foregroundColor(.white)
+            .foregroundColor(isSelected == buttonIndex ? .primaryBrown : .white)
             .shadow(color: Color.primaryShadowGray, radius: CaffeineBookDetailLayoutValue.Radius.sizeButtonShadow, x: .zero, y: .zero)
             .overlay(
                 VStack(spacing: .zero) {
                     Text(size)
                         .font(.title2)
-                        .foregroundColor(.customBlack)
+                        .foregroundColor(isSelected == buttonIndex ? .white : .customBlack)
                     Text(volume)
                         .padding(.top, CaffeineBookDetailLayoutValue.Padding.buttonTextSpace)
                         .font(.caption)
-                        .foregroundColor(.secondaryTextGray)
+                        .foregroundColor(isSelected == buttonIndex ? .white : .secondaryTextGray)
                 }
             )
             .onTapGesture {
-                //TODO: Button Toggle Logic
+                isSelected = buttonIndex
             }
     }
 }
@@ -172,6 +181,6 @@ struct CaffeineInfoRow: View {
 
 struct CaffeineBookDetailView_Previews: PreviewProvider {
     static var previews: some View {
-        CaffeineBookDetailView()
+            CaffeineBookDetailView()
     }
 }

--- a/Techome/Techome/Views/CaffeineBookDetail/CaffeineBookDetailView.swift
+++ b/Techome/Techome/Views/CaffeineBookDetail/CaffeineBookDetailView.swift
@@ -41,10 +41,8 @@ struct CaffeineBookDetailLayoutValue {
 
 struct CaffeineBookDetailView: View {
     
-    @State var Test : Beverage = dummyBeverages[0]
-    
-    @State var isSelected: Int = 0
-    
+    var caffeineBookDetailStates = CaffeineBookDetailStateHolder()
+        
     var body: some View {
         NavigationView {
             ZStack {
@@ -52,10 +50,11 @@ struct CaffeineBookDetailView: View {
                 
                 VStack {
                     VStack(alignment: .center, spacing: .zero) {
-                        CaffeineBeverage(test: Test)
-                        CaffeineSizeButtonGroup(test: Test, isSelected: $isSelected)
-                        CaffeineInfoGroup(test: Test, isSelected: $isSelected)
+                        CaffeineBeverage()
+                        CaffeineSizeButtonGroup()
+                        CaffeineInfoGroup()
                     }
+                    .environmentObject(caffeineBookDetailStates)
                     .background(.white)
                     .clipShape(RoundedRectangle(cornerRadius: CaffeineBookDetailLayoutValue.Radius.backgroundCard))
                     .padding(.horizontal, CaffeineBookDetailLayoutValue.Padding.backgroundHorizantal)
@@ -82,16 +81,16 @@ struct CaffeineBookDetailView: View {
 
 struct CaffeineBeverage: View {
     
-    var test: Beverage
+    @EnvironmentObject var caffeineBookDetailStates: CaffeineBookDetailStateHolder
     
     var body: some View {
-        Text(test.name)
+        Text(caffeineBookDetailStates.Beverage.name)
             .font(.title)
             .fontWeight(.bold)
             .foregroundColor(.customBlack)
             .padding(.top, CaffeineBookDetailLayoutValue.Padding.titleTop)
         
-        Text(test.franchise.getFranchiseName())
+        Text(caffeineBookDetailStates.Beverage.franchise.getFranchiseName())
             .font(.caption)
             .foregroundColor(.secondaryTextGray)
             .padding(.top, CaffeineBookDetailLayoutValue.Padding.franchiseTop)
@@ -99,13 +98,13 @@ struct CaffeineBeverage: View {
 }
 
 struct CaffeineSizeButtonGroup: View {
-    var test: Beverage
-    @Binding var isSelected: Int
+
+    @EnvironmentObject var caffeineBookDetailStates: CaffeineBookDetailStateHolder
 
     var body: some View {
         HStack(spacing: CaffeineBookDetailLayoutValue.Padding.buttonBetweenSpace) {
-            ForEach(0 ..< test.sizeInfo.count, id: \.self) { buttonIndex in
-                CaffeineSizeButton(size: test.sizeInfo[buttonIndex].name, volume: test.franchise.getSizeAmount(size: test.sizeInfo[buttonIndex].name), buttonIndex: buttonIndex, isSelected: $isSelected)
+            ForEach(0 ..< caffeineBookDetailStates.Beverage.sizeInfo.count, id: \.self) { buttonIndex in
+                CaffeineSizeButton(size: caffeineBookDetailStates.Beverage.sizeInfo[buttonIndex].name, volume: caffeineBookDetailStates.Beverage.franchise.getSizeAmount(size: caffeineBookDetailStates.Beverage.sizeInfo[buttonIndex].name), buttonIndex: buttonIndex)
             }
         }
         .padding(.top, CaffeineBookDetailLayoutValue.Padding.buttonGroupTop)
@@ -115,45 +114,43 @@ struct CaffeineSizeButtonGroup: View {
 
 struct CaffeineSizeButton: View {
     
+    @EnvironmentObject var caffeineBookDetailStates: CaffeineBookDetailStateHolder
+    
     var size: String
     var volume: Int
     var buttonIndex: Int
-    
-    @Binding var isSelected: Int
-    
+        
     var body: some View {
         RoundedRectangle(cornerRadius: CaffeineBookDetailLayoutValue.Radius.sizeButton)
             .frame(width: CaffeineBookDetailLayoutValue.Size.sizeButtonWidth, height: CaffeineBookDetailLayoutValue.Size.sizeButtonHeight)
-            .foregroundColor(isSelected == buttonIndex ? .primaryBrown : .white)
+            .foregroundColor(caffeineBookDetailStates.isSelected == buttonIndex ? .primaryBrown : .white)
             .shadow(color: Color.primaryShadowGray, radius: CaffeineBookDetailLayoutValue.Radius.sizeButtonShadow, x: .zero, y: .zero)
             .overlay(
                 VStack(spacing: .zero) {
                     Text(size)
                         .font(.title2)
-                        .foregroundColor(isSelected == buttonIndex ? .white : .customBlack)
+                        .foregroundColor(caffeineBookDetailStates.isSelected == buttonIndex ? .white : .customBlack)
                     Text("\(String(volume))ml")
                         .padding(.top, CaffeineBookDetailLayoutValue.Padding.buttonTextSpace)
                         .font(.caption)
-                        .foregroundColor(isSelected == buttonIndex ? .white : .secondaryTextGray)
+                        .foregroundColor(caffeineBookDetailStates.isSelected == buttonIndex ? .white : .secondaryTextGray)
                 }
             )
             .onTapGesture {
-                isSelected = buttonIndex
+                caffeineBookDetailStates.isSelected = buttonIndex
             }
     }
 }
 
 struct CaffeineInfoGroup: View {
     
-    var test: Beverage
-    
-    @Binding var isSelected: Int
-    
+    @EnvironmentObject var caffeineBookDetailStates: CaffeineBookDetailStateHolder
+        
     var body: some View {
         Group {
-            CaffeineInfoRow(label: "샷 수", info: String(test.sizeInfo[isSelected].defaultShotCount)+"샷")
+            CaffeineInfoRow(label: "샷 수", info: String(caffeineBookDetailStates.Beverage.sizeInfo[caffeineBookDetailStates.isSelected].defaultShotCount)+"샷")
                 .padding(.top, CaffeineBookDetailLayoutValue.Padding.infoRowBetweenSpaceExceptCaption)
-            CaffeineInfoRow(label: "카페인", info: String(test.sizeInfo[isSelected].caffeineAmount) + "mg")
+            CaffeineInfoRow(label: "카페인", info: String(caffeineBookDetailStates.Beverage.sizeInfo[caffeineBookDetailStates.isSelected].caffeineAmount) + "mg")
                 .padding(.top, CaffeineBookDetailLayoutValue.Padding.infoRowBetweenSpaceExceptCaption)
             HStack {
                 Spacer()


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- CaffeineBookDetailView에서 동작하는 로직 구현
- Size 별로 다른 샷 수, 카페인 양을 보여줌

1. Figma 화면
https://user-images.githubusercontent.com/81340603/173782485-4612e902-37ce-4d80-a1f7-efa23d90b773.mov
2. 화면 데모 영상
![DictionaryDetail](https://user-images.githubusercontent.com/81340603/173783014-30e9bed2-2a88-475f-8ff0-3df6d744aa1d.png)

## Key Changes 🔥 (주요 구현/변경 사항)
- 버튼 눌렀을 때 event handling
- 버튼 중 하나를 선택하면 다른 하나를 자동으로 취소할 수 있도록 logic 구현
- CaffeineView에서 전달 받을 beverage 와 연결: 지금은 dummydata에 연동함, 추후 변경 예정
- CaffeineDetailStateHolder 파일 추가 및 공통적으로 사용하는 State migration

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
1) 아직 '배출' 부분은 IntakeManager의 getRemainTimeToCharge 메소드가 수정되지 않아서 해당 메소드가 수정되면 pull 받아서 연결할 예정입니다. 
2) CaffeineView 와 연결할 때 dummydata 대신 선택된 data로 코드 수정할 예정입니다.
위 부분 감안해서 확인 부탁드립니다. :)

## ToDo 📆 (남은 작업)
- [ ] '배출' 부분 IntakeManager의 getRemainTimeToCharge 메소드 수정되면 호출해서 반영하기
- [ ] CaffeineView와 연결할 때 Navigation goBack() 코드 추가
- [ ] CaffeineView와 연결할 때 dummydata 대신 beverage 로 변경

## Reference 🔗
없음